### PR TITLE
Add guest login feature

### DIFF
--- a/client/src/Pages/Registration/Registration.js
+++ b/client/src/Pages/Registration/Registration.js
@@ -3,7 +3,7 @@ import { observer } from 'mobx-react-lite';
 import React, { useContext, useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Context } from '../..';
-import { check, login, registration } from '../../http/usersApi';
+import { check, login, registration, guestLogin } from '../../http/usersApi';
 import '../../styles/Registration.scss'
 
 const Registration = observer(() => {
@@ -128,22 +128,29 @@ const Registration = observer(() => {
 			})
 		}
 	}
-	const loginHandler = async () => {
-		try {
-			let data
-			const formData = new FormData()
-			formData.append('email', loginEmail)
-			formData.append('password', loginPassword)
-			data = await login(formData)
-			console.log(data);
-			user.setUser(data)
-			user.setIsAuth(true)
-			navigate('/home')
-		} catch (e) {
-			alert(e.response.data.message)
-			console.log(e)
-		}
-	}
+        const loginHandler = async () => {
+                try {
+                        let data
+                        const formData = new FormData()
+                        formData.append('email', loginEmail)
+                        formData.append('password', loginPassword)
+                        data = await login(formData)
+                        console.log(data);
+                        user.setUser(data)
+                        user.setIsAuth(true)
+                        navigate('/home')
+                } catch (e) {
+                        alert(e.response.data.message)
+                        console.log(e)
+                }
+        }
+
+        const guestHandler = async () => {
+                const data = await guestLogin()
+                user.setUser(data)
+                user.setIsAuth(true)
+                navigate('/home')
+        }
 
 	console.log(toJS(user));
 	// ! save user Data in Store and localStorage
@@ -299,9 +306,10 @@ const Registration = observer(() => {
 						<input type='password' value={loginPassword} onChange={e => setLoginPassword(e.target.value)} />
 					</div>
 				</div>
-				<div className="submit">
-					<button onClick={() => loginHandler()}>Log in</button>
-				</div>
+                                <div className="submit">
+                                        <button onClick={() => loginHandler()}>Log in</button>
+                                        <button style={{marginLeft: '20px'}} onClick={() => guestHandler()}>Continue as Guest</button>
+                                </div>
 				<div className="links">
 					<a onClick={() => setIsLogin(!isLogin)}>New to KFT? - register</a>
 					<a className='forgotPasword' onClick={() => redirect('recovery')} >Forgot password?</a>

--- a/client/src/http/usersApi.js
+++ b/client/src/http/usersApi.js
@@ -27,9 +27,15 @@ export const friendRequest = async(userId, friendId) => {
 }
 
 export const login = async(user) => {
-	const {data} = await $host.post('/api/users/login', user)
-	localStorage.setItem('token', data.token)
-	return jwt_decode(data.token)
+        const {data} = await $host.post('/api/users/login', user)
+        localStorage.setItem('token', data.token)
+        return jwt_decode(data.token)
+}
+
+export const guestLogin = async() => {
+        const {data} = await $host.post('/api/users/guest-login')
+        localStorage.setItem('token', data.token)
+        return jwt_decode(data.token)
 }
 
 export const getExactUser = async(id,userId) => {

--- a/controllers/userController.js
+++ b/controllers/userController.js
@@ -96,9 +96,9 @@ class UserController {
 		}
 	}
 
-	async login(req, res, next) {
-		try {
-			let { email, password } = req.body
+        async login(req, res, next) {
+                try {
+                        let { email, password } = req.body
 			let id
 			// console.log('login wtf', email)
 			await UserInfo.findOne({
@@ -126,12 +126,41 @@ class UserController {
 			delete user.password
 			delete user.user_info.mediaList
 
-			const token = generateJwt(user, 'reg/log')
-			return res.json({ token })
-		} catch (error){
-			return next(ApiError.internal(error))
-		}
-	}
+                        const token = generateJwt(user, 'reg/log')
+                        return res.json({ token })
+                } catch (error){
+                        return next(ApiError.internal(error))
+                }
+        }
+
+        async guestLogin(req, res, next) {
+                try {
+                        const guest = {
+                                id: 0,
+                                userName: 'Guest',
+                                profilePicture: 'nopfp.webp',
+                                role: 'GUEST',
+                                isOnline: false,
+                                user_info: {
+                                        email: 'guest@example.com',
+                                        phoneNumber: null,
+                                        groupList: [],
+                                        friendList: [],
+                                        birthYear: 1970,
+                                        birthMonth: 1,
+                                        birthDay: 1,
+                                        status: 'Guest profile',
+                                        tokenVersion: 0,
+                                        isPrivate: false,
+                                        profileHeaderPicture: 'defaultProfileHeader.png'
+                                }
+                        }
+                        const token = generateJwt(guest, 'reg/log')
+                        return res.json({ token })
+                } catch (error) {
+                        return next(ApiError.internal(error))
+                }
+        }
 	async check(req, res, next) {
 		// console.log(req.user)
 		try {

--- a/routes/userRouter.js
+++ b/routes/userRouter.js
@@ -7,6 +7,7 @@ const passport = require('passport');
 
 router.post('/registration', UserController.registration)
 router.post('/login',  UserController.login)
+router.post('/guest-login', UserController.guestLogin)
 router.get('/check', authMiddleware, UserController.check)
 router.put('/update/:id', UserController.update)
 router.get('/getAll', UserController.getAll) //checkRole('ADMIN')


### PR DESCRIPTION
Summary

- A guest-access endpoint was added in the Express router. The user router now exposes POST /guest-login for obtaining a guest token
- The controller implements guestLogin to create a static guest profile and return a JWT. This method appears after the regular login function
- The frontend HTTP util adds guestLogin() that calls /api/users/guest-login, storing the token and decoding user data with jwt_decode
- Registration page imports this helper and provides a “Continue as Guest” option, which signs the user in without registration

This change enables visitors to bypass normal registration and immediately enter the application as a guest user.